### PR TITLE
Add Xquik OpenAPI tool parsing fixture

### DIFF
--- a/openapi2callables/parse.py
+++ b/openapi2callables/parse.py
@@ -133,9 +133,14 @@ def parse_spec(
                     # Initialize parameters dictionary
                     parameters = {}
 
-                    # Process path, query, header, and cookie parameters
-                    if "parameters" in method_data:
-                        for param in method_data["parameters"]:
+                    # Process path-level parameters first, then let operation-level
+                    # definitions override matching name and location pairs.
+                    parameter_definitions = {
+                        (param["name"], param.get("in", "query")): param
+                        for param in [*path_data.get("parameters", []), *method_data.get("parameters", [])]
+                    }
+                    if parameter_definitions:
+                        for param in parameter_definitions.values():
                             param_name = param["name"]
                             param_in = param.get("in", "query")
                             param_required = param.get("required", False)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -141,6 +141,152 @@ def test_parse_spec_with_security():
     assert result["secure_get"]["security"] == [{"apiKeyAuth": []}]
 
 
+def test_parse_spec_includes_path_level_parameters_with_operation_overrides():
+    spec = {
+        "paths": {
+            "/pirates/{pirate_id}": {
+                "parameters": [
+                    {
+                        "name": "pirate_id",
+                        "in": "path",
+                        "required": True,
+                        "description": "Path-level description",
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "name": "request_trace",
+                        "in": "header",
+                        "description": "Inherited request trace",
+                        "schema": {"type": "string", "minLength": 8},
+                    },
+                ],
+                "get": {
+                    "operationId": "get_pirate",
+                    "parameters": [
+                        {
+                            "name": "pirate_id",
+                            "in": "path",
+                            "required": True,
+                            "description": "Operation-level description",
+                            "schema": {"type": "integer", "minimum": 1},
+                        }
+                    ],
+                },
+            }
+        }
+    }
+
+    result = parse_spec(spec)
+
+    assert result["get_pirate"]["parameters"]["pirate_id"] == {
+        "_type": "path",
+        "required": True,
+        "type": "integer",
+        "description": "Operation-level description",
+        "minimum": 1,
+    }
+    assert result["get_pirate"]["parameters"]["request_trace"] == {
+        "_type": "header",
+        "required": False,
+        "type": "string",
+        "description": "Inherited request trace",
+        "minLength": 8,
+    }
+
+
+def test_parse_spec_xquik_search_fixture():
+    spec = {
+        "openapi": "3.1.0",
+        "info": {
+            "title": "Xquik API",
+            "version": "1.0",
+            "description": "Xquik is an independent third-party service. Not affiliated with X Corp.",
+        },
+        "servers": [{"url": "https://xquik.com"}],
+        "paths": {
+            "/api/v1/x/tweets/search": {
+                "get": {
+                    "operationId": "searchTweets",
+                    "summary": "Search Tweets",
+                    "security": [{"apiKey": []}],
+                    "parameters": [
+                        {
+                            "name": "query",
+                            "in": "query",
+                            "required": True,
+                            "schema": {"type": "string"},
+                        }
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "Search results",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["data"],
+                                        "properties": {
+                                            "data": {
+                                                "type": "array",
+                                                "items": {
+                                                    "$ref": "#/components/schemas/Tweet",
+                                                },
+                                            }
+                                        },
+                                    }
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Tweet": {
+                    "type": "object",
+                    "required": ["id", "text"],
+                    "properties": {
+                        "id": {"type": "string"},
+                        "text": {"type": "string"},
+                    },
+                }
+            },
+            "securitySchemes": {
+                "apiKey": {
+                    "type": "apiKey",
+                    "name": "x-api-key",
+                    "in": "header",
+                }
+            },
+        },
+    }
+
+    result = parse_spec(spec)
+
+    assert result["searchTweets"]["path"] == "/api/v1/x/tweets/search"
+    assert result["searchTweets"]["method"] == "get"
+    assert result["searchTweets"]["security"] == [{"apiKey": []}]
+    assert result["searchTweets"]["parameters"]["query"]["type"] == "string"
+    assert result["searchTweets"]["responses"]["200"]["schema"] == {
+        "type": "object",
+        "properties": {
+            "data": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": "string",
+                        "text": "string",
+                    },
+                    "required": ["id", "text"],
+                },
+            }
+        },
+        "required": ["data"],
+    }
+
+
 def test_parse_spec_with_complex_request_body():
     spec = {
         "paths": {


### PR DESCRIPTION
## Summary

- Adds a compact Xquik OpenAPI search fixture to parser tests.
- Verifies operation ID, API-key security, query parameters, and resolved response schemas.
- Preserves the required independent-service notice.
- Fixes Path Item Object parameters being silently dropped.
- Applies operation-level overrides by OpenAPI parameter name and location.

## Independent Repository Fix

`parse_spec` previously read only operation-level parameters. Valid parameters declared on a Path Item Object disappeared from generated tools. The parser now inherits path-level parameters and lets operation-level definitions override matching name and location pairs as OpenAPI specifies.

The regression test verifies an untouched inherited header plus a path parameter override, including location, requirement status, type, description, and constraints.

## Validation

- `uv run --python 3.13 ruff check openapi2callables/parse.py tests/test_parse.py` passed.
- `uv run --python 3.13 ruff format --check openapi2callables/parse.py tests/test_parse.py` passed.
- `uv run --python 3.13 pytest -q` passed all 74 tests.
- Coverage reports 75% statements and 71% with branch measurement.
- `uv build --python 3.13` built the source distribution and wheel.
- `git diff --check upstream/main...HEAD` passed.

The contribution is squashed into 1 SSH-signed commit verified by GitHub.
